### PR TITLE
Fix: Update PanOrbit for Bevy 0.4 syntax

### DIFF
--- a/bevy-cookbook.md
+++ b/bevy-cookbook.md
@@ -304,7 +304,7 @@ fn pan_orbit_camera(
     let mut translation = Vec2::zero();
     let mut rotation_move = Vec2::default();
     let mut scroll = 0.0;
-    let dt = time.delta_seconds;
+    let dt = time.delta_seconds();
 
     if mousebtn.pressed(MouseButton::Right) {
         for ev in state.reader_motion.iter(&ev_motion) {
@@ -329,8 +329,8 @@ fn pan_orbit_camera(
             let window_h = window.height() as f32;
 
             // Link virtual sphere rotation relative to window to make it feel nicer
-            let delta_x = rotation_move.x() / window_w * std::f32::consts::PI * 2.0;
-            let delta_y = rotation_move.y() / window_h * std::f32::consts::PI;
+            let delta_x = rotation_move.x / window_w * std::f32::consts::PI * 2.0;
+            let delta_y = rotation_move.y / window_h * std::f32::consts::PI;
 
             let delta_yaw = Quat::from_rotation_y(delta_x);
             let delta_pitch = Quat::from_rotation_x(delta_y);
@@ -342,23 +342,20 @@ fn pan_orbit_camera(
             trans.rotation = look.to_scale_rotation_translation().1;
         } else {
             // The plane is x/y while z is "up". Multiplying by dt allows for a constant pan rate
-            let mut translation = Vec3::new(-translation.x() * dt, translation.y() * dt, 0.0);
+            let mut translation = Vec3::new(-translation.x * dt, translation.y * dt, 0.0);
             camera.focus += translation;
-            *translation.z_mut() = -scroll;
+            translation.z = -scroll;
             trans.translation += translation;
         }
     }
 }
 
-// Spawn a camera like this:
-
-fn spawn_camera(mut commands: Commands) {
+/// Spawn a camera like this.
+fn spawn_camera(commands: &mut Commands) {
     commands.spawn((PanOrbitCamera::default(),))
-        .with_bundle(Camera3dComponents {
-            ..Default::default()
-        });
+        .with_bundle(Camera3dBundle::default())
+        .insert_resource(InputState::default());
 }
-
 ```
 
 ## Display framerate in console


### PR DESCRIPTION
Just some quick fixes to make Pan Orbit camera work for Bevy 0.4.